### PR TITLE
Fixed hashlib usage

### DIFF
--- a/anonymize_logs/anon_helper.py
+++ b/anonymize_logs/anon_helper.py
@@ -1,9 +1,10 @@
-# import hashlib
+import hashlib
 import urlparse
-import md5py
+#import md5py
 
 
 class Helper(object):
+
     def __call__(self, argument):
         return argument
 
@@ -19,8 +20,8 @@ class Helper(object):
             return 'http', 'unknown domain', 'rest'
 
     def _hash_string(self, s):
-        # return hashlib.md5(s)
-        return md5py.md5(s).hexdigest()
+        return hashlib.md5(s).hexdigest()
+        #return md5py.md5(s).hexdigest()
 
     def _anonymize_uri(self, uri):
         parts = self._uri_parts(uri)

--- a/anonymize_logs/anonymize_logs.py
+++ b/anonymize_logs/anonymize_logs.py
@@ -16,6 +16,7 @@ import json
 from pyspark import SparkContext
 
 from anon_helper import Helper
+
 if __name__ == "__main__":
     if len(sys.argv) != 2 and len(sys.argv) != 3:
         print >> sys.stderr, "Usage: %s <input_file> [output_dir]" % (sys.argv[0])
@@ -28,7 +29,8 @@ if __name__ == "__main__":
     inputRDD = sc.textFile(input_file)
 
     helper = Helper()
-    anonEventRDD = inputRDD.map(lambda l: helper.anonymize_event(json.loads(l)))
+    #anonEventRDD = inputRDD.map(lambda l: helper.anonymize_event(json.loads(l)))
+    anonEventRDD = inputRDD.map(json.loads).map(helper.anonymize_event)
 
     if len(sys.argv) == 3:
         anonEventRDD.coalesce(anonEventRDD.getNumPartitions() - 1)\


### PR DESCRIPTION
Simple fix to get hashlib version of log anonymizer to work. Basically the issue was that the original version of Helper._hash_string() returns hashlib object instead of hexdigest of the md5 hash. The hashlib object has an internal state to support hash updates etc. and hashlib does not support pickling. 
